### PR TITLE
chore: more permissive in init checks

### DIFF
--- a/core/src/main/java/com/icell/external/carlosformito/core/CarlosFormManager.kt
+++ b/core/src/main/java/com/icell/external/carlosformito/core/CarlosFormManager.kt
@@ -242,7 +242,6 @@ class CarlosFormManager(
      * @param visible The new visibility state of the field.
      */
     override fun onFieldVisibilityChanged(id: String, visible: Boolean) {
-        checkInitialized()
         if (fieldVisibility.value[id] != visible) {
             fieldVisibility.update { visibilityMap ->
                 visibilityMap.toMutableMap().apply { put(id, visible) }


### PR DESCRIPTION
Visibility changes of a field behind the scenes only updates a map of visibility values. It has not direct relation with auto validations, so  checking init for the formManager is unnecessary in this case.